### PR TITLE
Change emoji based on environment

### DIFF
--- a/sms/sms_sender.py
+++ b/sms/sms_sender.py
@@ -8,12 +8,29 @@ client = Client(account_sid, auth_token)
 from_number = os.environ["TWILIO_FROM_NUMBER"]
 to_number = os.environ["TWILIO_TO_NUMBER"]
 
+def _get_bool_env(var_name: str, default: bool = False) -> bool:
+    value = os.environ.get(var_name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in ("1", "true", "yes", "on"):  # enabled
+        return True
+    if normalized in ("0", "false", "no", "off"):  # disabled
+        return False
+    return default
+
 def send_message(text):
-    # Append a friendly emoji to all outgoing SMS messages
-    text_with_emoji = f"{text} 🙂"
+    # Optionally append an emoji to outgoing SMS messages, controlled via env
+    append_emoji = _get_bool_env("SMS_APPEND_EMOJI", default=True)
+    configured_emoji = os.environ.get("SMS_EMOJI", "🙂")
+
+    if append_emoji and configured_emoji:
+        text_to_send = f"{text} {configured_emoji}"
+    else:
+        text_to_send = text
     message = client.messages \
                 .create(
-                    body=text_with_emoji,
+                    body=text_to_send,
                     from_=from_number,
                     to=to_number
                 )


### PR DESCRIPTION
Make the SMS message emoji optional and configurable via environment variables to allow user control.

---
[Slack Thread](https://looq-workspace.slack.com/archives/D09T9QFSR4J/p1763324668379329?thread_ts=1763324668.379329&cid=D09T9QFSR4J)

<a href="https://cursor.com/background-agent?bcId=bc-9892cdee-024a-47dd-b15a-6ecdeac96a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9892cdee-024a-47dd-b15a-6ecdeac96a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

